### PR TITLE
Changing the default to true.

### DIFF
--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -137,7 +137,7 @@ variable "allow_major_version_upgrade" {
 
 variable "auto_minor_version_upgrade" {
   description = "Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window"
-  default     = false
+  default     = true
 }
 
 variable "apply_immediately" {


### PR DESCRIPTION
The db_instance module sets the minor version upgrade default to true
but the rds module sets the default to false. Setting the rds default to
true to align these to provide consistant behaviour.