### PR TITLE
NIT-40 correct clustering configuration

### DIFF
--- a/alfresco-content/data.tf
+++ b/alfresco-content/data.tf
@@ -160,3 +160,11 @@ data "terraform_remote_state" "transform" {
     region = var.region
   }
 }
+
+#-------------------------------------------------------------
+### Getting Subnet CIDRs
+#-------------------------------------------------------------
+data "aws_subnet" "ecs_subnets" {
+  for_each = toset(local.subnet_ids)
+  id       = each.value
+}

--- a/alfresco-content/security_group.tf
+++ b/alfresco-content/security_group.tf
@@ -144,3 +144,23 @@ resource "aws_security_group_rule" "access_out" {
   to_port                  = local.app_port
   protocol                 = "tcp"
 }
+
+resource "aws_security_group_rule" "hazelcast_in" {
+  cidr_blocks       = [for s in data.aws_subnet.ecs_subnets : s.cidr_block]
+  security_group_id = aws_security_group.app.id
+  type              = "ingress"
+  from_port         = 5701
+  to_port           = 5701
+  protocol          = "tcp"
+  description       = "Hazelcast cluster"
+}
+
+resource "aws_security_group_rule" "hazelcast_out" {
+  cidr_blocks       = [for s in data.aws_subnet.ecs_subnets : s.cidr_block]
+  security_group_id = aws_security_group.app.id
+  type              = "egress"
+  from_port         = 5701
+  to_port           = 5701
+  protocol          = "tcp"
+  description       = "Hazelcast cluster"
+}

--- a/alfresco-content/templates/config/runtime.conf
+++ b/alfresco-content/templates/config/runtime.conf
@@ -31,3 +31,4 @@
 -Dsystem.workflow.engine.activiti.enabled=false
 -Dserver.allowWrite=${server_allowWrite}
 -Ddb.schema.update=${db_schema_update}
+-Dhazelcast.local.localAddress=$(grep $(hostname) /etc/hosts | cut -f1)

--- a/alfresco-read-only/data.tf
+++ b/alfresco-read-only/data.tf
@@ -160,3 +160,11 @@ data "terraform_remote_state" "transform" {
     region = var.region
   }
 }
+
+#-------------------------------------------------------------
+### Getting Subnet CIDRs
+#-------------------------------------------------------------
+data "aws_subnet" "ecs_subnets" {
+  for_each = toset(local.subnet_ids)
+  id       = each.value
+}

--- a/alfresco-read-only/security_group.tf
+++ b/alfresco-read-only/security_group.tf
@@ -144,3 +144,23 @@ resource "aws_security_group_rule" "access_out" {
   to_port                  = local.target_group_port
   protocol                 = "tcp"
 }
+
+resource "aws_security_group_rule" "hazelcast_in" {
+  cidr_blocks       = [for s in data.aws_subnet.ecs_subnets : s.cidr_block]
+  security_group_id = aws_security_group.app.id
+  type              = "ingress"
+  from_port         = 5701
+  to_port           = 5701
+  protocol          = "tcp"
+  description       = "Hazelcast cluster"
+}
+
+resource "aws_security_group_rule" "hazelcast_out" {
+  cidr_blocks       = [for s in data.aws_subnet.ecs_subnets : s.cidr_block]
+  security_group_id = aws_security_group.app.id
+  type              = "egress"
+  from_port         = 5701
+  to_port           = 5701
+  protocol          = "tcp"
+  description       = "Hazelcast cluster"
+}

--- a/alfresco-read-only/templates/config/runtime.conf
+++ b/alfresco-read-only/templates/config/runtime.conf
@@ -31,3 +31,4 @@
 -Dsystem.workflow.engine.activiti.enabled=false
 -Dserver.allowWrite=${server_allowWrite}
 -Ddb.schema.update=${db_schema_update}
+-Dhazelcast.local.localAddress=$(grep $(hostname) /etc/hosts | cut -f1)


### PR DESCRIPTION
Alfresco nodes were failing to join a cluster as networking in the ECS implementation of the infrastructure wouldn't allow traffic between nodes.