### PR TITLE
NIT-40 temporarily increase resource allocations

### DIFF
--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.879.0
+export ENV_CONFIGS_VERSION=1.889.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"


### PR DESCRIPTION
This is to allow a single alfresco-content instance to handle expected load while we tested a resilient version of the implementation