### PR TITLE
Fix to avoid cached upstream IPs and blocking of specific endpoint

### DIFF
--- a/alfresco-proxy/data.tf
+++ b/alfresco-proxy/data.tf
@@ -140,14 +140,20 @@ data "aws_acm_certificate" "cert" {
   most_recent = true
 }
 
+#-------------------------------------------------------------
+### Getting VPC CIDR - required because we want to derive the Amazon DNS Server IP for the VPC
+#-------------------------------------------------------------
+data "aws_vpc" "vpc" {
+  id = local.vpc_id
+}
+
 # Nginx template
 data "template_file" "nginx_host" {
   template = file("${path.module}/templates/config/host.conf")
 
   vars = {
-    alfresco_endpoint     = data.terraform_remote_state.content.outputs.info["end_point"]
-    share_endpoint        = data.terraform_remote_state.share.outputs.info["end_point"]
-    server_name           = "proxy"
-    health_check_endpoint = local.alfresco_proxy_props["health_check_endpoint"]
+    alfresco_endpoint = data.terraform_remote_state.content.outputs.info["end_point"]
+    share_endpoint    = data.terraform_remote_state.share.outputs.info["end_point"]
+    vpc_dns_ip        = cidrhost(data.aws_vpc.vpc.cidr_block, 2) # Derive IP of Amazon DNS endpoint in VPC
   }
 }

--- a/alfresco-proxy/templates/config/host.conf
+++ b/alfresco-proxy/templates/config/host.conf
@@ -1,10 +1,4 @@
-upstream alfresco_endpoint {
-        server ${alfresco_endpoint} max_fails=3 fail_timeout=10s;
-}
-
-upstream share_endpoint {
-        server ${share_endpoint} max_fails=3 fail_timeout=10s;
-}
+resolver ${vpc_dns_ip};
 
 server {
         server_tokens off;
@@ -12,29 +6,34 @@ server {
         client_max_body_size 10000M;
         client_body_buffer_size 128K;
         proxy_read_timeout 600s;
-        server_name ${server_name};
+        server_name proxy;
+
+        set $share_endpoint "${share_endpoint}";
+        set $alfresco_endpoint "${alfresco_endpoint}";
 
         location / {
                 rewrite ^/$ /share/page/;
         }
 
         location /share {
-                proxy_pass http://share_endpoint/share;
+                proxy_pass http://$share_endpoint;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
                 proxy_set_header        X-Forwarded-Server      $host;
         }
 
-        location ~ (^/share/.*/thumbnails/.*$)  {
-                proxy_pass http://share_endpoint;
+        location /alfresco/service/noms-spg/search {
+                limit_req zone=search burst=20 nodelay;
+                proxy_pass http://$alfresco_endpoint;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
                 proxy_set_header        X-Forwarded-Server      $host;
         }
+
         location /alfresco {
-                proxy_pass http://alfresco_endpoint/alfresco;
+                proxy_pass http://$alfresco_endpoint;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
@@ -42,7 +41,7 @@ server {
         }
 
         location /noms-spg {
-                proxy_pass http://alfresco_endpoint/alfresco/service/noms-spg;
+                proxy_pass http://$alfresco_endpoint/alfresco/service/noms-spg;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
@@ -50,7 +49,7 @@ server {
         }
 
         location /admin-spg {
-                proxy_pass http://alfresco_endpoint/alfresco/service/admin-spg;
+                proxy_pass http://$alfresco_endpoint/alfresco/service/admin-spg;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
@@ -58,37 +57,32 @@ server {
 
         }
 
-        location /mts-spg {
-                proxy_pass http://alfresco_endpoint/alfresco/service/mts-spg;
-                proxy_set_header        X-Real-IP       $remote_addr;
-                proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header        host    $host;
-                proxy_set_header        X-Forwarded-Server      $host;
-        }
-
+        # Required for IWP component 
         location /_vti_inf.html {
-                proxy_pass http://alfresco_endpoint/_vti_inf.html;
+                proxy_pass http://$alfresco_endpoint/_vti_inf.html;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
                 proxy_set_header        X-Forwarded-Server      $host;
         }
+
+        # Required for IWP component 
         location /_vti_bin {
-                proxy_pass http://alfresco_endpoint/_vti_bin;
+                proxy_pass http://$alfresco_endpoint/_vti_bin;
                 proxy_set_header        X-Real-IP       $remote_addr;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header        host    $host;
                 proxy_set_header        X-Forwarded-Server      $host;
         }
-        location /alfresco/service/noms-spg/search {
-                limit_req zone=search burst=20 nodelay;
-                proxy_pass http://alfresco_endpoint/alfresco/service/noms-spg/search;
-                proxy_set_header        X-Real-IP       $remote_addr;
-                proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header        host    $host;
-                proxy_set_header        X-Forwarded-Server      $host;
+
+
+        #  30/3/2022 Added to block a currently failing text content search
+        location /alfresco/service/noms-spg/search/text {
+                default_type application/json;
+                return 404 '{"status": "404", "message": "02300013 SOLR based search disabled or Solr server is not responding at this time."}';
         }
-        location ${health_check_endpoint} {
+
+        location /h3alth/checkz {
                 access_log off;
                 return 200 "healthy\n";
         }


### PR DESCRIPTION
This is a fix to solve a problem seen in multiple environments (including production) where by nginx caches on startup the DNS-resolved IP of the AWS internal load balancer. When AWS rotates this IP, nginx sends requests to the cached, expired IP.

Also, there's an addition of a hard-coded 404 response to block requests a specific endpoint which otherwise would return a more confusing response.