### PR TITLE
Added in config options for download cleaner

### DIFF
--- a/alfresco-content/main.tf
+++ b/alfresco-content/main.tf
@@ -44,10 +44,10 @@ locals {
   external_private_dns_host = data.terraform_remote_state.external_load_balancer.outputs.info["dns_hostname"]
   lb_security_group         = data.terraform_remote_state.load_balancer.outputs.info["security_group_id"]
 
-  solr_port        = 8983
-  app_port         = tonumber(local.alfresco_content_props["app_port"])
-  http_protocol    = "HTTP"
-  container_name   = local.application_name
+  solr_port      = 8983
+  app_port       = tonumber(local.alfresco_content_props["app_port"])
+  http_protocol  = "HTTP"
+  container_name = local.application_name
   url_path_patterns = [
     "/*"
   ]

--- a/alfresco-content/ssm.tf
+++ b/alfresco-content/ssm.tf
@@ -5,26 +5,28 @@ resource "aws_ssm_parameter" "config" {
   value = templatefile(
     "${path.module}/templates/config/runtime.conf",
     {
-      db_name           = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
-      db_user           = data.aws_ssm_parameter.db_user.value
-      db_password       = data.aws_ssm_parameter.db_password.value
-      db_endpoint       = data.terraform_remote_state.rds.outputs.info["address"]
-      memory            = tonumber(local.alfresco_content_props["memory"])
-      solr_host         = local.internal_private_dns_host
-      solr_port         = local.solr_port
-      share_host        = local.internal_private_dns_host
-      share_port        = 8070
-      alfresco_host     = format("https://%s", local.external_private_dns_host)
-      base_url_overwrite = format("https://%s", local.external_private_dns_host)
-      alfresco_port     = 443
-      alfresco_protocol = "https"
-      transform_host    = local.internal_private_dns_host
-      transform_port    = 8090
-      s3_bucket_name    = local.storage_bucket_name
-      s3_bucket_region  = local.region
-      cache_location    = local.cache_location
-      server_allowWrite = true
-      db_schema_update  = true
+      db_name                          = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
+      db_user                          = data.aws_ssm_parameter.db_user.value
+      db_password                      = data.aws_ssm_parameter.db_password.value
+      db_endpoint                      = data.terraform_remote_state.rds.outputs.info["address"]
+      memory                           = tonumber(local.alfresco_content_props["memory"])
+      solr_host                        = local.internal_private_dns_host
+      solr_port                        = local.solr_port
+      share_host                       = local.internal_private_dns_host
+      share_port                       = 8070
+      alfresco_host                    = format("https://%s", local.external_private_dns_host)
+      base_url_overwrite               = format("https://%s", local.external_private_dns_host)
+      alfresco_port                    = 443
+      alfresco_protocol                = "https"
+      transform_host                   = local.internal_private_dns_host
+      transform_port                   = 8090
+      s3_bucket_name                   = local.storage_bucket_name
+      s3_bucket_region                 = local.region
+      cache_location                   = local.cache_location
+      server_allowWrite                = true
+      db_schema_update                 = true
+      download_cleaner_repeat_delay_ms = 315569520000 # Set for a long time to effectively disable
+      download_cleaner_start_delay_ms  = 315569520000 # Set for a long time to effectively disable
     }
   )
   tags = local.tags

--- a/alfresco-content/templates/config/runtime.conf
+++ b/alfresco-content/templates/config/runtime.conf
@@ -32,3 +32,6 @@
 -Dserver.allowWrite=${server_allowWrite}
 -Ddb.schema.update=${db_schema_update}
 -Dhazelcast.local.localAddress=$(grep $(hostname) /etc/hosts | cut -f1)
+-Ddownload.cleaner.cleanAllSysDownloadFolders=false
+-Ddownload.cleaner.repeatIntervalMilliseconds=${download_cleaner_repeat_delay_ms}
+-Ddownload.cleaner.startDelayMilliseconds=${download_cleaner_start_delay_ms}

--- a/alfresco-read-only/ssm.tf
+++ b/alfresco-read-only/ssm.tf
@@ -5,26 +5,28 @@ resource "aws_ssm_parameter" "config" {
   value = templatefile(
     "${path.module}/templates/config/runtime.conf",
     {
-      db_name           = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
-      db_user           = data.aws_ssm_parameter.db_user.value
-      db_password       = data.aws_ssm_parameter.db_password.value
-      db_endpoint       = data.terraform_remote_state.rds.outputs.info["address"]
-      memory            = tonumber(local.alfresco_ro_content_props["memory"])
-      solr_host         = local.internal_private_dns_host
-      solr_port         = local.solr_port
-      share_host        = local.internal_private_dns_host
-      share_port        = 8070
-      alfresco_host     = format("http://%s", local.internal_private_dns_host)
-      base_url_overwrite = format("http://%s:%s", local.internal_private_dns_host, local.target_group_port)
-      alfresco_port     = local.target_group_port
-      alfresco_protocol = "http"
-      transform_host    = local.internal_private_dns_host
-      transform_port    = 8090
-      s3_bucket_name    = local.storage_bucket_name
-      s3_bucket_region  = local.region
-      cache_location    = local.cache_location
-      server_allowWrite = false
-      db_schema_update  = false
+      db_name                          = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
+      db_user                          = data.aws_ssm_parameter.db_user.value
+      db_password                      = data.aws_ssm_parameter.db_password.value
+      db_endpoint                      = data.terraform_remote_state.rds.outputs.info["address"]
+      memory                           = tonumber(local.alfresco_ro_content_props["memory"])
+      solr_host                        = local.internal_private_dns_host
+      solr_port                        = local.solr_port
+      share_host                       = local.internal_private_dns_host
+      share_port                       = 8070
+      alfresco_host                    = format("http://%s", local.internal_private_dns_host)
+      base_url_overwrite               = format("http://%s:%s", local.internal_private_dns_host, local.target_group_port)
+      alfresco_port                    = local.target_group_port
+      alfresco_protocol                = "http"
+      transform_host                   = local.internal_private_dns_host
+      transform_port                   = 8090
+      s3_bucket_name                   = local.storage_bucket_name
+      s3_bucket_region                 = local.region
+      cache_location                   = local.cache_location
+      server_allowWrite                = false
+      db_schema_update                 = false
+      download_cleaner_repeat_delay_ms = 315569520000 # Set for a long time to effectively disable
+      download_cleaner_start_delay_ms  = 315569520000 # Set for a long time to effectively disable
     }
   )
   tags = local.tags

--- a/alfresco-read-only/templates/config/runtime.conf
+++ b/alfresco-read-only/templates/config/runtime.conf
@@ -32,3 +32,6 @@
 -Dserver.allowWrite=${server_allowWrite}
 -Ddb.schema.update=${db_schema_update}
 -Dhazelcast.local.localAddress=$(grep $(hostname) /etc/hosts | cut -f1)
+-Ddownload.cleaner.cleanAllSysDownloadFolders=false
+-Ddownload.cleaner.repeatIntervalMilliseconds=${download_cleaner_repeat_delay_ms}
+-Ddownload.cleaner.startDelayMilliseconds=${download_cleaner_start_delay_ms}


### PR DESCRIPTION
Optimised config related to the download cleaner functionality in the content and read-only Alfresco components.
Specifically, the config options involving durations are being changed to prevent the automatic removal of subject-access request archives.