### PR TITLE
NIT-87 stop blocking search endpoint

### DIFF
--- a/alfresco-proxy/templates/config/host.conf
+++ b/alfresco-proxy/templates/config/host.conf
@@ -75,13 +75,6 @@ server {
                 proxy_set_header        X-Forwarded-Server      $host;
         }
 
-
-        #  30/3/2022 Added to block a currently failing text content search
-        location /alfresco/service/noms-spg/search/text {
-                default_type application/json;
-                return 404 '{"status": "404", "message": "02300013 SOLR based search disabled or Solr server is not responding at this time."}';
-        }
-
         location /h3alth/checkz {
                 access_log off;
                 return 200 "healthy\n";


### PR DESCRIPTION
This change is in preparation for unblocking of the search endpoint. Indexing is now finished in production, which means users can be allowed to search once testing is done