### PR TITLE
NIT-90 optimise solr backup policy

### DIFF
--- a/alfresco-search-solr/backup.tf
+++ b/alfresco-search-solr/backup.tf
@@ -29,11 +29,11 @@ resource "aws_backup_plan" "solr_backup" {
   rule {
     rule_name         = "${local.common_name}-ebs-bkup"
     target_vault_name = aws_backup_vault.solr_backup.name
-    schedule          = local.alfresco_search_solr_props["schedule"]
+    schedule          = local.alfresco_search_solr_props["backup_schedule"]
 
     lifecycle {
-      cold_storage_after = local.alfresco_search_solr_props["cold_storage_after"]
-      delete_after       = local.alfresco_search_solr_props["delete_after"]
+      cold_storage_after = local.alfresco_search_solr_props["backup_cold_storage_after"]
+      delete_after       = local.alfresco_search_solr_props["backup_delete_after"]
     }
   }
 

--- a/alfresco-search-solr/main.tf
+++ b/alfresco-search-solr/main.tf
@@ -10,7 +10,7 @@ terraform {
 ####################################################
 
 locals {
-  alfresco_search_solr_props   = merge(var.alfresco_search_solr_props, var.alfresco_search_solr_configs)
+  alfresco_search_solr_props   = merge(var.alfresco_search_solr_props, var.alfresco_search_solr_configs, var.alfresco_search_solr_configs_overrides)
   region                       = var.region
   account_id                   = data.terraform_remote_state.common.outputs.common_account_id
   vpc_id                       = data.terraform_remote_state.common.outputs.vpc_id

--- a/alfresco-search-solr/variables.tf
+++ b/alfresco-search-solr/variables.tf
@@ -17,26 +17,31 @@ variable "alf_cloudwatch_log_retention" {
 variable "alfresco_search_solr_props" {
   type = map(string)
   default = {
-    cpu                = "1024"
-    memory             = "4096"
-    app_port           = "8983"
-    heap_size          = "1500"
-    image_url          = "alfresco/alfresco-search-services"
-    version            = "2.0.2"
-    ebs_size           = "100"
-    ebs_iops           = "100"
-    ebs_type           = "gp2"
-    ssm_prefix         = "/alfresco/ecs"
-    desired_count      = "3"
-    cookie_duration    = "3600"
-    schedule           = "cron(0 01 * * ? *)"
-    cold_storage_after = 14
-    delete_after       = 120
-    snap_tag           = "CreateSnapshotSolr"
+    cpu                       = "1024"
+    memory                    = "4096"
+    app_port                  = "8983"
+    heap_size                 = "1500"
+    image_url                 = "alfresco/alfresco-search-services"
+    version                   = "2.0.2"
+    ebs_size                  = "100"
+    ebs_iops                  = "100"
+    ebs_type                  = "gp2"
+    ssm_prefix                = "/alfresco/ecs"
+    desired_count             = "3"
+    cookie_duration           = "3600"
+    backup_schedule           = "cron(0 01 * * ? *)"
+    backup_cold_storage_after = 7
+    backup_delete_after       = 14
+    snap_tag                  = "CreateSnapshotSolr"
   }
 }
 
 variable "alfresco_search_solr_configs" {
+  type    = map(string)
+  default = {}
+}
+
+variable "alfresco_search_solr_configs_overrides" {
   type    = map(string)
   default = {}
 }

--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.912.0
+export ENV_CONFIGS_VERSION=1.930.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"


### PR DESCRIPTION
This change allows us to control the backup policy with more granularity. There is no reason for longterm backups of non-prod environments