### PR TITLE
NIT-158 point alfresco-dev at latest image tags

### DIFF
--- a/alfresco-content/content.tf
+++ b/alfresco-content/content.tf
@@ -31,7 +31,7 @@ module "ecs_service" {
   container_definitions = templatefile(
     "${path.module}/templates/task_definitions/${local.task_definition_file}",
     {
-      image_url         = format("%s:%s", local.alfresco_content_props["image_url"], local.alfresco_content_props["version"])
+      image_url         = format("%s:%s", local.alfresco_content_props["image_url"], local.prefix == "tf-alf-dev" ? "latest" : local.alfresco_content_props["version"])
       container_name    = local.application_name
       region            = local.region
       loggroup          = module.create_loggroup.loggroup_name

--- a/alfresco-read-only/content.tf
+++ b/alfresco-read-only/content.tf
@@ -31,7 +31,7 @@ module "ecs_service" {
   container_definitions = templatefile(
     "${path.module}/templates/task_definitions/${local.task_definition_file}",
     {
-      image_url         = format("%s:%s", local.alfresco_ro_content_props["image_url"], local.alfresco_ro_content_props["version"])
+      image_url         = format("%s:%s", local.alfresco_ro_content_props["image_url"], local.prefix == "tf-alf-dev" ? "latest" : local.alfresco_ro_content_props["version"])
       container_name    = local.application_name
       region            = local.region
       loggroup          = module.create_loggroup.loggroup_name

--- a/alfresco-share/share.tf
+++ b/alfresco-share/share.tf
@@ -27,7 +27,7 @@ module "ecs_service" {
   container_definitions = templatefile(
     "${path.module}/templates/task_definitions/${local.task_definition_file}",
     {
-      image_url            = format("%s:%s", local.alfresco_share_props["image_url"], local.alfresco_share_props["version"])
+      image_url            = format("%s:%s", local.alfresco_share_props["image_url"], local.prefix == "tf-alf-dev" ? "latest" : local.alfresco_share_props["version"])
       container_name       = local.container_name
       region               = local.region
       loggroup             = module.create_loggroup.loggroup_name

--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.951.0
+export ENV_CONFIGS_VERSION=1.982.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"


### PR DESCRIPTION
This is to allow Zaizi devs to push and test images in alfresco-dev without our intervention