### PR TITLE
NIT-170 Tag RDS database with Phase1 for correct auto start/stop order

### DIFF
--- a/database/database.tf
+++ b/database/database.tf
@@ -36,7 +36,13 @@ module "database" {
   snapshot_identifier             = lookup(var.alf_rds_props, "snapshot_identifier", "alfresco-snapshot")
   storage_encrypted               = true
   storage_type                    = lookup(var.alf_rds_props, "storage_type", "gp2")
-  tags                            = local.tags
   username                        = local.db_user_name
   vpc_security_group_ids          = flatten(local.security_group_ids)
+
+  tags = merge(
+    local.tags,
+    {
+      "autostop-${var.environment_type}" = "Phase1"
+    }
+  )
 }


### PR DESCRIPTION
Databases need to be started before application servers and stopped after application servers. Current value of this tag, which is True would result in RDS databases being stopped at the same time as application servers. This may lead to data loss/corruption.