### PR TITLE
Adding db pool properties to read and content

### DIFF
--- a/alfresco-content/ssm.tf
+++ b/alfresco-content/ssm.tf
@@ -5,28 +5,34 @@ resource "aws_ssm_parameter" "config" {
   value = templatefile(
     "${path.module}/templates/config/runtime.conf",
     {
-      db_name                          = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
-      db_user                          = data.aws_ssm_parameter.db_user.value
-      db_password                      = data.aws_ssm_parameter.db_password.value
-      db_endpoint                      = data.terraform_remote_state.rds.outputs.info["address"]
-      memory                           = tonumber(local.alfresco_content_props["memory"])
-      solr_host                        = local.internal_private_dns_host
-      solr_port                        = local.solr_port
-      share_host                       = local.internal_private_dns_host
-      share_port                       = 8070
-      alfresco_host                    = format("https://%s", local.external_private_dns_host)
-      base_url_overwrite               = format("https://%s", local.external_private_dns_host)
-      alfresco_port                    = 443
-      alfresco_protocol                = "https"
-      transform_host                   = local.internal_private_dns_host
-      transform_port                   = 8090
-      s3_bucket_name                   = local.storage_bucket_name
-      s3_bucket_region                 = local.region
-      cache_location                   = local.cache_location
-      server_allowWrite                = true
-      db_schema_update                 = true
-      download_cleaner_repeat_delay_ms = 315569520000 # Set for a long time to effectively disable
-      download_cleaner_start_delay_ms  = 315569520000 # Set for a long time to effectively disable
+      db_name                               = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
+      db_user                               = data.aws_ssm_parameter.db_user.value
+      db_password                           = data.aws_ssm_parameter.db_password.value
+      db_endpoint                           = data.terraform_remote_state.rds.outputs.info["address"]
+      memory                                = tonumber(local.alfresco_content_props["memory"])
+      solr_host                             = local.internal_private_dns_host
+      solr_port                             = local.solr_port
+      share_host                            = local.internal_private_dns_host
+      share_port                            = 8070
+      alfresco_host                         = format("https://%s", local.external_private_dns_host)
+      base_url_overwrite                    = format("https://%s", local.external_private_dns_host)
+      alfresco_port                         = 443
+      alfresco_protocol                     = "https"
+      transform_host                        = local.internal_private_dns_host
+      transform_port                        = 8090
+      s3_bucket_name                        = local.storage_bucket_name
+      s3_bucket_region                      = local.region
+      cache_location                        = local.cache_location
+      server_allowWrite                     = true
+      db_schema_update                      = true
+      download_cleaner_repeat_delay_ms      = 315569520000 # Set for a long time to effectively disable
+      download_cleaner_start_delay_ms       = 315569520000 # Set for a long time to effectively disable
+      db_pool_initial                       = local.alfresco_content_props["db_pool_initial"]
+      db_pool_max                           = local.alfresco_content_props["db_pool_max"]
+      db_pool_evict_idle_min                = 90000
+      db_pool_evict_interval                = 300000
+      db_pool_evict_num_tests               = 5
+      content_transformer_default_timeoutMs = 90000
     }
   )
   tags = local.tags

--- a/alfresco-content/templates/config/runtime.conf
+++ b/alfresco-content/templates/config/runtime.conf
@@ -36,3 +36,10 @@
 -Ddownload.cleaner.repeatIntervalMilliseconds=${download_cleaner_repeat_delay_ms}
 -Ddownload.cleaner.startDelayMilliseconds=${download_cleaner_start_delay_ms}
 -Dalfresco.cluster.enabled=false
+-Ddb.pool.initial=${db_pool_initial}
+-Ddb.pool.max=${db_pool_max}
+-Ddb.pool.abandoned.detect=true
+-Ddb.pool.evict.idle.min=${db_pool_evict_idle_min}
+-Ddb.pool.evict.interval=${db_pool_evict_interval}
+-Ddb.pool.evict.num.tests=${db_pool_evict_num_tests}
+-Dcontent.transformer.default.timeoutMs=${content_transformer_default_timeoutMs}

--- a/alfresco-read-only/ssm.tf
+++ b/alfresco-read-only/ssm.tf
@@ -5,28 +5,34 @@ resource "aws_ssm_parameter" "config" {
   value = templatefile(
     "${path.module}/templates/config/runtime.conf",
     {
-      db_name                          = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
-      db_user                          = data.aws_ssm_parameter.db_user.value
-      db_password                      = data.aws_ssm_parameter.db_password.value
-      db_endpoint                      = data.terraform_remote_state.rds.outputs.info["address"]
-      memory                           = tonumber(local.alfresco_ro_content_props["memory"])
-      solr_host                        = local.internal_private_dns_host
-      solr_port                        = local.solr_port
-      share_host                       = local.internal_private_dns_host
-      share_port                       = 8070
-      alfresco_host                    = format("http://%s", local.internal_private_dns_host)
-      base_url_overwrite               = format("http://%s:%s", local.internal_private_dns_host, local.target_group_port)
-      alfresco_port                    = local.target_group_port
-      alfresco_protocol                = "http"
-      transform_host                   = local.internal_private_dns_host
-      transform_port                   = 8090
-      s3_bucket_name                   = local.storage_bucket_name
-      s3_bucket_region                 = local.region
-      cache_location                   = local.cache_location
-      server_allowWrite                = false
-      db_schema_update                 = false
-      download_cleaner_repeat_delay_ms = 315569520000 # Set for a long time to effectively disable
-      download_cleaner_start_delay_ms  = 315569520000 # Set for a long time to effectively disable
+      db_name                               = data.terraform_remote_state.rds.outputs.rds_creds["db_name"]
+      db_user                               = data.aws_ssm_parameter.db_user.value
+      db_password                           = data.aws_ssm_parameter.db_password.value
+      db_endpoint                           = data.terraform_remote_state.rds.outputs.info["address"]
+      memory                                = tonumber(local.alfresco_ro_content_props["memory"])
+      solr_host                             = local.internal_private_dns_host
+      solr_port                             = local.solr_port
+      share_host                            = local.internal_private_dns_host
+      share_port                            = 8070
+      alfresco_host                         = format("http://%s", local.internal_private_dns_host)
+      base_url_overwrite                    = format("http://%s:%s", local.internal_private_dns_host, local.target_group_port)
+      alfresco_port                         = local.target_group_port
+      alfresco_protocol                     = "http"
+      transform_host                        = local.internal_private_dns_host
+      transform_port                        = 8090
+      s3_bucket_name                        = local.storage_bucket_name
+      s3_bucket_region                      = local.region
+      cache_location                        = local.cache_location
+      server_allowWrite                     = false
+      db_schema_update                      = false
+      download_cleaner_repeat_delay_ms      = 315569520000 # Set for a long time to effectively disable
+      download_cleaner_start_delay_ms       = 315569520000 # Set for a long time to effectively disable
+      db_pool_initial                       = local.alfresco_ro_content_props["db_pool_initial"]
+      db_pool_max                           = local.alfresco_ro_content_props["db_pool_max"]
+      db_pool_evict_idle_min                = 90000
+      db_pool_evict_interval                = 300000
+      db_pool_evict_num_tests               = 5
+      content_transformer_default_timeoutMs = 90000
     }
   )
   tags = local.tags

--- a/alfresco-read-only/templates/config/runtime.conf
+++ b/alfresco-read-only/templates/config/runtime.conf
@@ -36,3 +36,10 @@
 -Ddownload.cleaner.repeatIntervalMilliseconds=${download_cleaner_repeat_delay_ms}
 -Ddownload.cleaner.startDelayMilliseconds=${download_cleaner_start_delay_ms}
 -Dalfresco.cluster.enabled=false
+-Ddb.pool.initial=${db_pool_initial}
+-Ddb.pool.max=${db_pool_max}
+-Ddb.pool.abandoned.detect=true
+-Ddb.pool.evict.idle.min=${db_pool_evict_idle_min}
+-Ddb.pool.evict.interval=${db_pool_evict_interval}
+-Ddb.pool.evict.num.tests=${db_pool_evict_num_tests}
+-Dcontent.transformer.default.timeoutMs=${content_transformer_default_timeoutMs}

--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.982.0
+export ENV_CONFIGS_VERSION=1.1018.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"


### PR DESCRIPTION
Work item - https://dsdmoj.atlassian.net/browse/NIT-206

Following a PR to env_configs (https://github.com/ministryofjustice/hmpps-env-configs/pull/2037), this change is to set db pool connection properties for the read and content services, in line with Zaizi recommendations.