### PR TITLE
Increment config version to consume fixed config for alfresco-dev

### DIFF
--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.1018.0
+export ENV_CONFIGS_VERSION=1.1021.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"


### PR DESCRIPTION
Workitem: https://dsdmoj.atlassian.net/browse/NIT-206

A follow up to https://github.com/ministryofjustice/hmpps-env-configs/pull/2046, to apply fixed configs to alfresco-dev.
The db pool variable values weren't being consumed.