### PR TITLE
Changes to upgrade alfresco db from 11.4 -> 11.14

### DIFF
--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.1036.0
+export ENV_CONFIGS_VERSION=1.1037.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"

--- a/database/database.tf
+++ b/database/database.tf
@@ -6,7 +6,7 @@ module "database" {
   source                          = "../modules/db_instance"
   allocated_storage               = lookup(var.alf_rds_props, "allocated_storage", 30)
   allow_major_version_upgrade     = false
-  apply_immediately               = false
+  apply_immediately               = true
   auto_minor_version_upgrade      = false
   backup_retention_period         = var.alf_data_import == "enabled" ? 0 : lookup(var.alf_rds_props, "backup_retention_period", 28)
   backup_window                   = lookup(var.alf_rds_props, "backup_window", "02:00-04:00")

--- a/database/main.tf
+++ b/database/main.tf
@@ -132,68 +132,71 @@ module "db_subnet_group" {
   tags        = local.tags
 }
 
+# Commenting this parameter group because alfresco-database instance uses the default parameter now, not these custom ones.
+# After this terraform has been applied (which will remove the parameter group), this code block can be removed.
 ############################################
 # CREATE PARAMETER GROUP
 ############################################
-
-module "parameter_group" {
-  source = "../modules/rds/db_parameter_group"
-
-  create      = true
-  identifier  = local.common_name
-  name_prefix = "${local.common_name}-"
-  family      = local.family
-
-  parameters = flatten(var.alf_db_parameters)
-
-  tags = local.tags
-}
-
-# ENBALE FOR RESTORE AND ATTACH TO PRIMARY NODE
-# module "restore_parameter_group" {
+# module "parameter_group" {
 #   source = "../modules/rds/db_parameter_group"
 
 #   create      = true
-#   identifier  = "${local.common_name}-restore"
-#   name_prefix = "${local.common_name}-restore-"
-#   family      = "${local.family}"
+#   identifier  = local.common_name
+#   name_prefix = "${local.common_name}-"
+#   family      = local.family
 
-#   parameters = [
-#     {
-#       name         = "maintenance_work_mem"
-#       value        = 1048576
-#       apply_method = "pending-reboot"
-#     },
-#     {
-#       name         = "max_wal_size"
-#       value        = 256
-#       apply_method = "pending-reboot"
-#     },
-#     {
-#       name         = "checkpoint_timeout"
-#       value        = 1800
-#       apply_method = "pending-reboot"
-#     },
-#     {
-#       name         = "synchronous_commit"
-#       value        = "Off"
-#       apply_method = "pending-reboot"
-#     },
-#     {
-#       name         = "wal_buffers"
-#       value        = 8192
-#       apply_method = "pending-reboot"
-#     },
-#     {
-#       name         = "autovacuum"
-#       value        = "Off"
-#       apply_method = "pending-reboot"
-#     }
-#   ]
+#   parameters = flatten(var.alf_db_parameters)
 
-#   tags = "${local.tags}"
+#   tags = local.tags
 # }
 
+# # ENBALE FOR RESTORE AND ATTACH TO PRIMARY NODE
+# # module "restore_parameter_group" {
+# #   source = "../modules/rds/db_parameter_group"
+
+# #   create      = true
+# #   identifier  = "${local.common_name}-restore"
+# #   name_prefix = "${local.common_name}-restore-"
+# #   family      = "${local.family}"
+
+# #   parameters = [
+# #     {
+# #       name         = "maintenance_work_mem"
+# #       value        = 1048576
+# #       apply_method = "pending-reboot"
+# #     },
+# #     {
+# #       name         = "max_wal_size"
+# #       value        = 256
+# #       apply_method = "pending-reboot"
+# #     },
+# #     {
+# #       name         = "checkpoint_timeout"
+# #       value        = 1800
+# #       apply_method = "pending-reboot"
+# #     },
+# #     {
+# #       name         = "synchronous_commit"
+# #       value        = "Off"
+# #       apply_method = "pending-reboot"
+# #     },
+# #     {
+# #       name         = "wal_buffers"
+# #       value        = 8192
+# #       apply_method = "pending-reboot"
+# #     },
+# #     {
+# #       name         = "autovacuum"
+# #       value        = "Off"
+# #       apply_method = "pending-reboot"
+# #     }
+# #   ]
+
+# #   tags = "${local.tags}"
+# # }
+
+# Unlike the commented-out block above relating to parameter groups (see note above), there are still numerous rds snapshots referencing
+#   the option group. So this can only be commented out when the snapshots are removed
 ############################################
 # CREATE DB OPTIONS
 ############################################


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-236

Changes to
- allow Terraform to upgrade alfresco-database rds instance from 11.4 to 11.14
- removal of old parameter group (no longer associated to any rds instances)