### PR TITLE
Bumping Alfresco RDS version to 11.7 and env_configs to latest

### DIFF
--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.1177.0
+export ENV_CONFIGS_VERSION=1.1266.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"

--- a/database/database.tf
+++ b/database/database.tf
@@ -15,7 +15,7 @@ module "database" {
   db_subnet_group_name            = module.db_subnet_group.db_subnet_group_id
   enabled_cloudwatch_logs_exports = flatten(local.enabled_cloudwatch_logs_exports)
   engine                          = local.engine
-  engine_version                  = lookup(var.alf_rds_props, "engine_version", "11.4")
+  engine_version                  = "11.17" # Latest minor version at time of writing - see https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
   final_snapshot_identifier       = "alfresco-database-final-snapshot"
   identifier                      = "alfresco-database"
   instance_class                  = lookup(var.alf_rds_props, "instance_class", "db.t2.medium")


### PR DESCRIPTION
Work item: nit501

Incrementing RDS version and version of env_configs used.
Testing changes between existing and new env_configs version only revealed a new allow list IP to be applied.

Note the removal of the rds instance version from env_configs (the alf-rds-props map). Previously this existed for each environment, with the same version. In an effort to simplify, it has been removed from the map, now referenced once in the terraform, with management of terraform release version in the alfresco infra versions repo.