### PR TITLE
Bumping Alfresco RDS version to 11.7 and env_configs to latest

### DIFF
--- a/configs/common.properties
+++ b/configs/common.properties
@@ -1,2 +1,2 @@
-export ENV_CONFIGS_VERSION=1.1177.0 #1.1266.0
+export ENV_CONFIGS_VERSION=1.1266.0
 export ENV_CONFIGS_REPO="https://github.com/ministryofjustice/hmpps-env-configs.git"

--- a/database/database.tf
+++ b/database/database.tf
@@ -15,7 +15,7 @@ module "database" {
   db_subnet_group_name            = module.db_subnet_group.db_subnet_group_id
   enabled_cloudwatch_logs_exports = flatten(local.enabled_cloudwatch_logs_exports)
   engine                          = local.engine
-  engine_version                  = lookup(var.alf_rds_props, "engine_version", "11.4") #"11.17" # Latest minor version at time of writing - see https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
+  engine_version                  = "11.17" # Latest minor version at time of writing - see https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
   final_snapshot_identifier       = "alfresco-database-final-snapshot"
   identifier                      = "alfresco-database"
   instance_class                  = lookup(var.alf_rds_props, "instance_class", "db.t2.medium")


### PR DESCRIPTION
Alfresco RDS upgrade has been removed for SR27 mini release to prod. SR 27 mini change can be reverted now.

Reverting to change done here - https://github.com/ministryofjustice/hmpps-delius-alfresco-shared-terraform/pull/414