### PR TITLE
NIT-589: add ecs:TagResource permission

### DIFF
--- a/ecs_cluster/templates/iam/ecs-host-role-policy.tpl
+++ b/ecs_cluster/templates/iam/ecs-host-role-policy.tpl
@@ -69,6 +69,7 @@
                 "ecs:RegisterContainerInstance",
                 "ecs:StartTelemetrySession",
                 "ecs:UpdateContainerInstancesState",
+                "ecs:TagResource",
                 "ecs:Submit*"
             ],
             "Resource": "*"


### PR DESCRIPTION
## Context
Amazon ECS is introducing a newly required IAM permission, `ecs:TagResource,` that supports tagging when creating ECS resources. 

Beginning on July 17, 2023, the default behavior for adding tags to newly created ECS resources will be set to "Deny". 

Once this default behavior is launched, any attempts to tag any newly created ECS resources will fail with an "AccessDenied" error if the ecs:TagResource permission is not added to the IAM policy of any principal creating the resource. i.e. the principal that the ECS container agent will assume

## Action
add `ecs:TagResource` permission to allow the Amazon ECS container agent to tag cluster on creation and to tag container instances when they are registered to a cluster.