### PR TITLE
remove alfreso-database from pre-prod only

### DIFF
--- a/database/database.tf
+++ b/database/database.tf
@@ -3,6 +3,7 @@
 ############################################
 
 module "database" {
+  count                           = var.environment == "pre-prod" ? 0 : 1
   source                          = "../modules/db_instance"
   allocated_storage               = lookup(var.alf_rds_props, "allocated_storage", 30)
   allow_major_version_upgrade     = false

--- a/database/output.tf
+++ b/database/output.tf
@@ -9,11 +9,11 @@ output "rds_creds" {
 
 output "info" {
   value = {
-    address               = module.database.db_instance_address
-    endpoint              = module.database.db_instance_endpoint
-    id                    = module.database.db_instance_id
-    allocated_storage     = module.database.db_instance_allocated_storage
-    max_allocated_storage = module.database.db_instance_max_allocated_storage
+    address               = try(module.database[0].db_instance_address, null)
+    endpoint              = try(module.database[0].db_instance_endpoint, null)
+    id                    = try(module.database[0].db_instance_id, null)
+    allocated_storage     = try(module.database[0].db_instance_allocated_storage, null)
+    max_allocated_storage = try(module.database[0].db_instance_max_allocated_storage, null)
     security_group_id     = data.terraform_remote_state.security-groups.outputs.security_groups_sg_rds_id
   }
 }

--- a/database/terragrunt.hcl
+++ b/database/terragrunt.hcl
@@ -9,3 +9,11 @@ dependencies {
     "../security-groups"
   ]
 }
+
+dependency "common" {
+  config_path = "../common"
+}
+
+inputs = {
+  environment = dependency.common.outputs.environment
+}

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -94,3 +94,7 @@ variable "alf_db_options" {
   description = "A list of Options to apply."
   default     = []
 }
+
+variable "environment" {
+  type = string
+}


### PR DESCRIPTION
This PR removes the _alfresco-database_ from **pre-production only**. This has been accomplished by using a conditional `count` based on the environment name.

This also requires the following 'state mv' command to be ran in other environments where this Terraform is deployed:
```sh
ENVIRONMENT=name-of-env COMPONENT=database tg state mv module.database 'module.database[0]'
```
Otherwise it will try to destroy and create a new database. This has command has already been ran in _delius-prod_.